### PR TITLE
Persist queue on logout in Facility app

### DIFF
--- a/mobile/src/AppDatabase.js
+++ b/mobile/src/AppDatabase.js
@@ -202,7 +202,6 @@ export class AppDatabase {
         const patient = await this.db.get(PATIENTS, event.enrollCode);
         const vaccinator = await this.db.get(VACCINATORS, event.vaccinatorId);
         const queue = await this.db.get(QUEUE, event.enrollCode);
-        console.log(patient, vaccinator, queue)
         if (patient && vaccinator && queue) {
             const vaccination = await programDb.getVaccinationDetails(event, patient.programId);
             return {
@@ -245,5 +244,3 @@ export class AppDatabase {
 }
 
 export const appIndexDb = new AppDatabase();
-
-

--- a/mobile/src/AppDatabase.js
+++ b/mobile/src/AppDatabase.js
@@ -239,47 +239,6 @@ export class AppDatabase {
             ]);
     }
 
-    async stashData() {
-        const userDetails = await this.getUserDetails()
-        if (userDetails && userDetails.mobile_number) {
-            const queue = await this.db.getAll(QUEUE);
-            const patients = await this.db.getAll(PATIENTS);
-
-            const stashUserData = {
-                userId: userDetails["mobile_number"],
-                queue: queue,
-                patients: patients
-            }
-            await this.db.put(STASH_DATA, stashUserData);
-        }
-    }
-
-    async popData() {
-        const userDetails = await this.getUserDetails()
-        if (userDetails && userDetails["mobile_number"]) {
-            const userId = userDetails["mobile_number"]
-            const stashQueue = await this.db.get(STASH_DATA, userId);
-            if (stashQueue) {
-                const queue = stashQueue.queue
-                if (queue && queue.length > 0) {
-                    for (const queueItem of queue) {
-                        await this.db.put(QUEUE, queueItem);
-                    }
-                }
-
-                const patients = stashQueue.patients
-                if (patients && patients.length > 0) {
-                    for (const patientItem of patients) {
-                        await this.db.put(PATIENTS, patientItem);
-                    }
-                }
-
-                await this.db.delete(STASH_DATA, userId);
-            }
-        }
-    }
-
-
     async getAllEvents() {
         return await this.db.getAll(EVENTS) || [];
     }

--- a/mobile/src/AppDatabase.js
+++ b/mobile/src/AppDatabase.js
@@ -5,7 +5,7 @@ import {programDb} from "./Services/ProgramDB";
 import {monthNames} from "./utils/date_utils";
 
 const DATABASE_NAME = "DivocDB";
-const DATABASE_VERSION = 13;
+const DATABASE_VERSION = 12;
 const PATIENTS = "patients";
 const PROGRAMS = "programs";
 const QUEUE = "queue";

--- a/mobile/src/AppDatabase.js
+++ b/mobile/src/AppDatabase.js
@@ -5,10 +5,11 @@ import {programDb} from "./Services/ProgramDB";
 import {monthNames} from "./utils/date_utils";
 
 const DATABASE_NAME = "DivocDB";
-const DATABASE_VERSION = 11;
+const DATABASE_VERSION = 13;
 const PATIENTS = "patients";
 const PROGRAMS = "programs";
 const QUEUE = "queue";
+const STASH_DATA = "stash_data";
 const EVENTS = "events";
 const VACCINATORS = "vaccinators";
 const STATUS = "status";
@@ -50,6 +51,10 @@ export class AppDatabase {
 
                 if (!objectNames.contains(PROGRAMS)) {
                     database.createObjectStore(PROGRAMS, {keyPath: "name"});
+                }
+
+                if (!objectNames.contains(STASH_DATA)) {
+                    database.createObjectStore(STASH_DATA, {keyPath: "userId"});
                 }
                 console.log("DB upgraded from " + oldVersion + " to " + newVersion)
             }
@@ -189,21 +194,26 @@ export class AppDatabase {
         const events = await this.db.getAll(EVENTS) || [];
         const certifyObjects = events.map((item, index) => this.getCertifyObject(item));
         const result = await Promise.all(certifyObjects);
-        return result;
+        const filterObjects = result.filter((item) => item.hasOwnProperty("patient"));
+        return filterObjects;
     }
 
     async getCertifyObject(event) {
         const patient = await this.db.get(PATIENTS, event.enrollCode);
         const vaccinator = await this.db.get(VACCINATORS, event.vaccinatorId);
         const queue = await this.db.get(QUEUE, event.enrollCode);
-        const vaccination = await programDb.getVaccinationDetails(event, patient.programId);
-        return {
-            vaccinatorName: vaccinator.name,
-            patient: patient,
-            enrollCode: event.enrollCode,
-            identity: queue.identity || "",
-            vaccination: vaccination
+        console.log(patient, vaccinator, queue)
+        if (patient && vaccinator && queue) {
+            const vaccination = await programDb.getVaccinationDetails(event, patient.programId);
+            return {
+                vaccinatorName: vaccinator.name,
+                patient: patient,
+                enrollCode: event.enrollCode,
+                identity: queue.identity || "",
+                vaccination: vaccination
+            }
         }
+        return {}
     }
 
     async cleanEvents() {
@@ -228,6 +238,47 @@ export class AppDatabase {
                 deleteUserDetails
             ]);
     }
+
+    async stashData() {
+        const userDetails = await this.getUserDetails()
+        if (userDetails && userDetails.mobile_number) {
+            const queue = await this.db.getAll(QUEUE);
+            const patients = await this.db.getAll(PATIENTS);
+
+            const stashUserData = {
+                userId: userDetails["mobile_number"],
+                queue: queue,
+                patients: patients
+            }
+            await this.db.put(STASH_DATA, stashUserData);
+        }
+    }
+
+    async popData() {
+        const userDetails = await this.getUserDetails()
+        if (userDetails && userDetails["mobile_number"]) {
+            const userId = userDetails["mobile_number"]
+            const stashQueue = await this.db.get(STASH_DATA, userId);
+            if (stashQueue) {
+                const queue = stashQueue.queue
+                if (queue && queue.length > 0) {
+                    for (const queueItem of queue) {
+                        await this.db.put(QUEUE, queueItem);
+                    }
+                }
+
+                const patients = stashQueue.patients
+                if (patients && patients.length > 0) {
+                    for (const patientItem of patients) {
+                        await this.db.put(PATIENTS, patientItem);
+                    }
+                }
+
+                await this.db.delete(STASH_DATA, userId);
+            }
+        }
+    }
+
 
     async getAllEvents() {
         return await this.db.getAll(EVENTS) || [];

--- a/mobile/src/Services/QueueDB.js
+++ b/mobile/src/Services/QueueDB.js
@@ -1,0 +1,60 @@
+import {appIndexDb} from "../AppDatabase";
+
+const PATIENTS = "patients";
+const QUEUE = "queue";
+const STASH_DATA = "stash_data";
+
+class QueueDB {
+
+
+    getDB() {
+        if (!this.db) {
+            this.db = appIndexDb.db;
+        }
+        return this.db
+    }
+
+    async stashData() {
+        const userDetails = await appIndexDb.getUserDetails()
+        const db = this.getDB();
+        if (userDetails && userDetails.mobile_number) {
+            const queue = await db.getAll(QUEUE);
+            const patients = await db.getAll(PATIENTS);
+
+            const stashUserData = {
+                userId: userDetails.mobile_number,
+                queue: queue,
+                patients: patients
+            }
+            await db.put(STASH_DATA, stashUserData);
+        }
+    }
+
+    async popData() {
+        const userDetails = await appIndexDb.getUserDetails()
+        const db = this.getDB();
+        if (userDetails && userDetails["mobile_number"]) {
+            const userId = userDetails["mobile_number"]
+            const stashQueue = await db.get(STASH_DATA, userId);
+            if (stashQueue) {
+                const queue = stashQueue.queue
+                if (queue && queue.length > 0) {
+                    for (const queueItem of queue) {
+                        await db.put(QUEUE, queueItem);
+                    }
+                }
+
+                const patients = stashQueue.patients
+                if (patients && patients.length > 0) {
+                    for (const patientItem of patients) {
+                        await db.put(PATIENTS, patientItem);
+                    }
+                }
+
+                await db.delete(STASH_DATA, userId);
+            }
+        }
+    }
+}
+
+export const queueDb = new QueueDB()

--- a/mobile/src/Services/QueueDB.js
+++ b/mobile/src/Services/QueueDB.js
@@ -43,18 +43,18 @@ class QueueDB {
                 const stashDate = new Date(stashQueue.date);
                 if (!is24hoursAgo(stashDate)) {
                     await this.saveQueue(stashQueue.queue);
-                    await this.savePatients(stashQueue.patients);
+                    await this.saveRecipient(stashQueue.patients);
                 }
                 await db.delete(STASH_DATA, userId);
             }
         }
     }
 
-    async savePatients(patients) {
-        if (patients && patients.length > 0) {
+    async saveRecipient(recipient) {
+        if (recipient && recipient.length > 0) {
             const db = this.getDB()
-            for (const patientItem of patients) {
-                await db.put(PATIENTS, patientItem);
+            for (const recipientItem of recipient) {
+                await db.put(PATIENTS, recipientItem);
             }
         }
     }

--- a/mobile/src/SyncFacade.js
+++ b/mobile/src/SyncFacade.js
@@ -1,7 +1,7 @@
 import {appIndexDb} from "./AppDatabase";
 import {ApiServices} from "./Services/ApiServices";
-import {getSelectedProgram, saveSelectedProgram} from "./components/ProgramSelection";
 import {programDb} from "./Services/ProgramDB";
+import {queueDb} from "./Services/QueueDB";
 
 const LAST_SYNC_KEY = "lastSyncedDate";
 
@@ -28,7 +28,7 @@ export class SyncFacade {
         const vaccinators = await ApiServices.fetchVaccinators();
         await appIndexDb.saveVaccinators(vaccinators);
 
-        await appIndexDb.popData()
+        await queueDb.popData()
     }
 
     static async push() {

--- a/mobile/src/SyncFacade.js
+++ b/mobile/src/SyncFacade.js
@@ -27,6 +27,8 @@ export class SyncFacade {
 
         const vaccinators = await ApiServices.fetchVaccinators();
         await appIndexDb.saveVaccinators(vaccinators);
+
+        await appIndexDb.popData()
     }
 
     static async push() {

--- a/mobile/src/components/Profile/index.js
+++ b/mobile/src/components/Profile/index.js
@@ -59,6 +59,7 @@ function AuthSafeUserProfile({keycloak}) {
                                     SyncFacade
                                         .push()
                                         .catch((e) => console.log(e.message))
+                                        .then(() => appIndexDb.stashData())
                                         .then(() => appIndexDb.clearEverything())
                                         .then((() => keycloak.logout({redirectUri: window.location.origin + config.urlPath})))
                                         .catch(e => {

--- a/mobile/src/components/Profile/index.js
+++ b/mobile/src/components/Profile/index.js
@@ -8,8 +8,8 @@ import Button from "react-bootstrap/Button";
 import {Messages} from "../../Base/Constants";
 import {AuthSafeComponent} from "../../utils/keycloak";
 import Col from "react-bootstrap/Col";
-import Row from "react-bootstrap/Row";
 import config from "../../config";
+import {queueDb} from "../../Services/QueueDB";
 
 function AuthSafeUserProfile({keycloak}) {
     const [userDetails, setUserDetails] = useState();
@@ -59,7 +59,7 @@ function AuthSafeUserProfile({keycloak}) {
                                     SyncFacade
                                         .push()
                                         .catch((e) => console.log(e.message))
-                                        .then(() => appIndexDb.stashData())
+                                        .then(() => queueDb.stashData())
                                         .then(() => appIndexDb.clearEverything())
                                         .then((() => keycloak.logout({redirectUri: window.location.origin + config.urlPath})))
                                         .catch(e => {


### PR DESCRIPTION
In the facility app, once a recipient is enrolled and before vaccination, if the facility staff logs out, the recipient data is lost !!!

We need to save the queue of the user when logging out in into the index DB in the device and when user logs in within the same device fetch and save the old queue from index db.