### PR TITLE
Minor Fixes

### DIFF
--- a/backend/registration_api/pkg/enrollment/enrollment_utils.go
+++ b/backend/registration_api/pkg/enrollment/enrollment_utils.go
@@ -2,6 +2,7 @@ package enrollment
 
 import (
 	"errors"
+
 	kernelService "github.com/divoc/kernel_library/services"
 	"github.com/divoc/registration-api/pkg/services"
 )
@@ -9,6 +10,9 @@ import (
 const RegistryName = "Enrollment"
 
 func DeleteRecipient(osid string) error {
+	if osid == "" {
+		return errors.New("osid is missing in the request")
+	}
 	updatePayload := map[string]interface{}{
 		"osid":             osid,
 		"code":             "deleted-code-" + osid,

--- a/backend/registration_api/pkg/handler.go
+++ b/backend/registration_api/pkg/handler.go
@@ -178,7 +178,7 @@ func canInitializeSlots() bool {
 }
 
 func initializeFacilitySlots(params operations.InitializeFacilitySlotsParams) middleware.Responder {
-	currentDate := time.Now()
+	currentDate := time.Now().Truncate(24 * time.Hour)
 	programDates, err := services.GetActiveProgramDates()
 	if err != nil {
 		return model.NewGenericServerError()

--- a/backend/registration_api/swagger_gen/restapi/embedded_spec.go
+++ b/backend/registration_api/swagger_gen/restapi/embedded_spec.go
@@ -371,6 +371,9 @@ func init() {
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Error"
           }
         }
       }
@@ -788,6 +791,9 @@ func init() {
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Error"
           }
         }
       }

--- a/backend/registration_api/swagger_gen/restapi/operations/delete_recipient_responses.go
+++ b/backend/registration_api/swagger_gen/restapi/operations/delete_recipient_responses.go
@@ -120,3 +120,27 @@ func (o *DeleteRecipientUnauthorized) WriteResponse(rw http.ResponseWriter, prod
 
 	rw.WriteHeader(401)
 }
+
+// DeleteRecipientInternalServerErrorCode is the HTTP code returned for type DeleteRecipientInternalServerError
+const DeleteRecipientInternalServerErrorCode int = 500
+
+/*DeleteRecipientInternalServerError Internal Error
+
+swagger:response deleteRecipientInternalServerError
+*/
+type DeleteRecipientInternalServerError struct {
+}
+
+// NewDeleteRecipientInternalServerError creates DeleteRecipientInternalServerError with default headers values
+func NewDeleteRecipientInternalServerError() *DeleteRecipientInternalServerError {
+
+	return &DeleteRecipientInternalServerError{}
+}
+
+// WriteResponse to the client
+func (o *DeleteRecipientInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(500)
+}

--- a/interfaces/registration-api.yaml
+++ b/interfaces/registration-api.yaml
@@ -164,6 +164,8 @@ paths:
                 type: string
         '401':
           description: Unauthorized
+        '500':
+         description: Internal Error
     post:
       summary: Enroll Recipient
       operationId: enrollRecipient


### PR DESCRIPTION
* return / log specific error messages while deleting recipient | when a user accidentally double clicks delete confirmation, the second request displays misleading error message saying there is an appointment associated with it 

* Initslot fails to init slots if program startDate and EndDate are same. This is because when calculating currentDate, the time is not truncated to zero hour so the dateValidity comparison fails (startDate <= date <= endDate)