### PR TITLE
update AppointmentInfo | walks-in after registration

### DIFF
--- a/backend/registration_api/pkg/consumers/recipients_appointment_consumer.go
+++ b/backend/registration_api/pkg/consumers/recipients_appointment_consumer.go
@@ -46,6 +46,10 @@ func StartRecipientsAppointmentBookingConsumer() {
 			}
 
 			responseFromRegistry, err := kernelService.ReadRegistry("Enrollment", appointmentAckMessage.EnrollmentOsid)
+			if err != nil {
+				log.Errorf("Error reading osid : %s from registry", appointmentAckMessage.EnrollmentOsid)
+				continue
+			}
 			enrollmentResp, ok := responseFromRegistry["Enrollment"].(map[string]interface{})
 			if !ok {
 				log.Errorf("Unable to fetch the Enrollment details for the recipient (%v) ", appointmentAckMessage.EnrollmentCode)
@@ -72,7 +76,7 @@ func StartRecipientsAppointmentBookingConsumer() {
 			}
 			if _, err = kernelService.UpdateRegistry("Enrollment", map[string]interface{}{
 				"osid": enrollment.Osid,
-				"appointments": enrollment.Appointments,
+				"appointments": services.DRefAppointments(enrollment.Appointments),
 			}); err != nil {
 				log.Error("Booking appointment failed ", err)
 				continue

--- a/backend/registration_api/pkg/services/enrollment_service.go
+++ b/backend/registration_api/pkg/services/enrollment_service.go
@@ -41,9 +41,12 @@ func CreateEnrollment(enrollmentPayload *EnrollmentPayload) error {
 	if dupEnrollment != nil {
 		enrollmentPayload.OverrideEnrollmentCode(dupEnrollment.Duplicate.Code)
 		duplicateErr := fmt.Errorf("enrollment with same %s already exists", dupEnrollment.Criteria)
-		if enrollmentPayload.EnrollmentType != models.EnrollmentEnrollmentTypePREENRL {
-			log.Error("Duplicates Found : ", duplicateErr)
-			return duplicateErr
+		log.Error("Duplicates Found : ", duplicateErr)
+		if enrollmentPayload.EnrollmentType == models.EnrollmentEnrollmentTypeWALKIN {
+			if len(enrollmentPayload.Appointments) == 0 {
+				return fmt.Errorf("walk-in enrollment with no appointment info")
+			}
+			return UpdateEnrollmentAppointmentInfo(*dupEnrollment.Duplicate, enrollmentPayload.Appointments[0])
 		}
 		if shouldAutoBookAppointment(enrollmentPayload) {
 			return BookAppointment(dupEnrollment.Duplicate.Phone, dupEnrollment.Duplicate.Code, enrollmentPayload.Appointments[0])
@@ -83,6 +86,39 @@ func CreateEnrollment(enrollmentPayload *EnrollmentPayload) error {
 	cacheEnrollmentInfo(enrollmentPayload.Enrollment, result.(string))
 	if shouldAutoBookAppointment(enrollmentPayload) {
 		return BookAppointment(enrollmentPayload.Phone, enrollmentPayload.Code, enrollmentPayload.Appointments[0])
+	}
+	return nil
+}
+
+func UpdateEnrollmentAppointmentInfo(enrollment enrollment, appointmentInfo *models.EnrollmentAppointmentsItems0) error {
+	log.Infof("Updating Booking Info for the enrollment %s", enrollment.Code)
+	existingAppointment := func() *models.EnrollmentAppointmentsItems0{
+		for _ , a := range enrollment.Appointments {
+			if a.ProgramID == appointmentInfo.ProgramID && a.Dose == appointmentInfo.Dose && !a.Certified {
+				log.Info("Enrollee has already booked an appointment. Overriding it")
+				return a
+			}
+		}
+		log.Info("Enrolle did not book an appointment. Adding it")
+		return nil
+	}()
+	if existingAppointment != nil {
+		existingAppointment.EnrollmentScopeID = appointmentInfo.EnrollmentScopeID
+		existingAppointment.AppointmentDate = appointmentInfo.AppointmentDate
+		existingAppointment.Certified = appointmentInfo.Certified
+		existingAppointment.AppointmentSlot = appointmentInfo.AppointmentSlot
+	} else {
+		enrollment.Appointments = append(enrollment.Appointments, appointmentInfo)
+	}
+
+	str, _ := json.Marshal(enrollment.Appointments)
+	log.Info("New Appointments : ", string(str))
+
+	if _, err := kernelService.UpdateRegistry("Enrollment", map[string]interface{}{
+		"osid": enrollment.Osid,
+		"appointments": DRefAppointments(enrollment.Appointments),
+	}); err != nil {
+		return err
 	}
 	return nil
 }
@@ -296,4 +332,14 @@ type DuplicateEnrollment struct {
 type enrollment struct {
 	Osid	string	`json:"osid"`
 	models.Enrollment
+}
+
+func DRefAppointments(ptrSlice []*models.EnrollmentAppointmentsItems0) []models.EnrollmentAppointmentsItems0 {
+	r := make([]models.EnrollmentAppointmentsItems0, 0, len(ptrSlice))
+	for _, a := range ptrSlice {
+		if a != nil {
+			r = append(r, *a)
+		}
+	}
+	return r
 }

--- a/backend/registration_api/pkg/utils/utils.go
+++ b/backend/registration_api/pkg/utils/utils.go
@@ -57,14 +57,16 @@ func SendOTP(prefix string, phone string, otp string) (*sns.PublishOutput, error
 	return resp, err
 }
 
-func ToMap(obj interface{}) map[string]interface{}{
-	if bytes, err := json.Marshal(obj); err == nil {
-		var resp map[string]interface{}
-		if err := json.Unmarshal(bytes, &resp); err == nil {
-			return resp
-		}
+func ToMap(obj interface{}) (map[string]interface{},error) {
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	var resp map[string]interface{}
+	if err := json.Unmarshal(bytes, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func GetTomorrowStart() time.Time {


### PR DESCRIPTION
If a registered user walks in to a facility these changes update appointment info [certified, date, facilityCode] in the existing Enrollment appointment. If there is no appointment one will be created and appointment will be marked as certifed