### PR TITLE
Bump vaccine-context package version to 1.0.8

### DIFF
--- a/verification/package-lock.json
+++ b/verification/package-lock.json
@@ -14491,9 +14491,9 @@
       }
     },
     "vaccination-context": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/vaccination-context/-/vaccination-context-1.0.7.tgz",
-      "integrity": "sha512-uJKwwuu6lfXJjo0V729IYBmT56e8e3DY8VLx45VxrPt9MohpOMejtA44a81yBqaUPlAmZaKV5VuZquaVbHPpRg=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vaccination-context/-/vaccination-context-1.0.8.tgz",
+      "integrity": "sha512-WTMrSHQi/oqieXBdEzQMCsYMbB952zFwT8uBJctW3D0fiafD7ewEhOqNGPlt9FEh5Lh/Vcix2vsCRHhKsyR/sw=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/verification/package.json
+++ b/verification/package.json
@@ -13,7 +13,7 @@
     "react-scripts": "4.0.3",
     "web-vitals": "^1.0.1",
     "jszip": "^3.5.0",
-    "vaccination-context": "^1.0.7",
+    "vaccination-context": "^1.0.8",
     "axios": "^0.21.0",
     "jsonld-signatures": "^6.0.0",
     "ramda": "^0.27.1",


### PR DESCRIPTION
This is to get code changes for UHID addition to vaccine-context. (Final certificates include the uhid fields)