### PR TITLE
HLM-513 

### DIFF
--- a/backend/vc-certification-service/src/controllers/certificate.controller.js
+++ b/backend/vc-certification-service/src/controllers/certificate.controller.js
@@ -83,44 +83,10 @@ async function revokeCertificate(req, res) {
         "limit": 1,
         "offset": 0
     }
-    // const flag = await sunbirdRegistryService.searchCertificate(req.body.entityName, filters, token)
-    // if(!flag) {
-    //     res.status(400).json({
-    //         message: `Entry for ${req.body.entityName} not found`
-    //     });
-    //     return;
-    // }
-    // let body = {
-    //     previousCertificateId: req.body.certificateId,
-    //     schema: req.body.entityName,
-    //     startDate: new Date(),
-    // }
-    // if(req.body.endDate) {
-    //     body = {...body, endDate: req.body.endDate}
-    // }
-    // try {
-    //     const certificateRevokeResponse = await sunbirdRegistryService.revokeCertificate(body, token);
-    //     res.status(200).json({
-    //         message: "Certificate Revoked",
-    //         certificateRevokeResponse: certificateRevokeResponse
-    //     })
-    // } catch(err) {
-    //     console.error(err);
-    //     res.status(err?.response?.status || 500).json({
-    //         message: err?.response?.data
-    //     });
-    // }
     sunbirdRegistryService.searchCertificate(req.body.entityName, filters, token)
     .then(async(result) => {
         if(result === true) {
-            let body = {
-                previousCertificateId: req.body.certificateId,
-                schema: req.body.entityName,
-                startDate: new Date(),
-            }
-            if(req.body.endDate) {
-                body = {...body, endDate: req.body.endDate}
-            }
+            let body = getRevokeBody(req);
             const certificateRevokeResponse = await sunbirdRegistryService.revokeCertificate(body, token);
             res.status(200).json({
                 message: "Certificate Revoked",
@@ -139,6 +105,18 @@ async function revokeCertificate(req, res) {
             message: err?.response?.data
         })
     })
+}
+
+function getRevokeBody(req) {
+    let body = {
+        previousCertificateId: req.body.certificateId,
+        schema: req.body.entityName,
+        startDate: new Date(),
+    }
+    if(req.body.endDate) {
+        body = {...body, endDate: req.body.endDate}
+    }
+    return body;
 }
 
 module.exports = {

--- a/backend/vc-certification-service/src/controllers/certificate.controller.js
+++ b/backend/vc-certification-service/src/controllers/certificate.controller.js
@@ -83,33 +83,62 @@ async function revokeCertificate(req, res) {
         "limit": 1,
         "offset": 0
     }
-    const flag = await sunbirdRegistryService.searchCertificate(req.body.entityName, filters, token)
-    if(!flag) {
-        res.status(400).json({
-            message: `Entry for ${req.body.entityName} not found`
-        });
-        return;
-    }
-    let body = {
-        previousCertificateId: req.body.certificateId,
-        schema: req.body.entityName,
-        startDate: new Date(),
-    }
-    if(req.body.endDate) {
-        body = {...body, endDate: req.body.endDate}
-    }
-    try {
-        const certificateRevokeResponse = await sunbirdRegistryService.revokeCertificate(body, token);
-        res.status(200).json({
-            message: "Certificate Revoked",
-            certificateRevokeResponse: certificateRevokeResponse
-        })
-    } catch(err) {
-        console.error(err);
+    // const flag = await sunbirdRegistryService.searchCertificate(req.body.entityName, filters, token)
+    // if(!flag) {
+    //     res.status(400).json({
+    //         message: `Entry for ${req.body.entityName} not found`
+    //     });
+    //     return;
+    // }
+    // let body = {
+    //     previousCertificateId: req.body.certificateId,
+    //     schema: req.body.entityName,
+    //     startDate: new Date(),
+    // }
+    // if(req.body.endDate) {
+    //     body = {...body, endDate: req.body.endDate}
+    // }
+    // try {
+    //     const certificateRevokeResponse = await sunbirdRegistryService.revokeCertificate(body, token);
+    //     res.status(200).json({
+    //         message: "Certificate Revoked",
+    //         certificateRevokeResponse: certificateRevokeResponse
+    //     })
+    // } catch(err) {
+    //     console.error(err);
+    //     res.status(err?.response?.status || 500).json({
+    //         message: err?.response?.data
+    //     });
+    // }
+    sunbirdRegistryService.searchCertificate(req.body.entityName, filters, token)
+    .then(async(result) => {
+        if(result === true) {
+            let body = {
+                previousCertificateId: req.body.certificateId,
+                schema: req.body.entityName,
+                startDate: new Date(),
+            }
+            if(req.body.endDate) {
+                body = {...body, endDate: req.body.endDate}
+            }
+            const certificateRevokeResponse = await sunbirdRegistryService.revokeCertificate(body, token);
+            res.status(200).json({
+                message: "Certificate Revoked",
+                certificateRevokeResponse: certificateRevokeResponse
+            });
+        }
+        else {
+            console.log('RESULT : ',result);
+            res.status(400).json({
+                message: `Entry for ${req.body.entityName} not found`
+            })
+        }
+    }).catch(err => {
+        console.log('ERROR : ',err?.response?.status || '');
         res.status(err?.response?.status || 500).json({
             message: err?.response?.data
-        });
-    }
+        })
+    })
 }
 
 module.exports = {

--- a/backend/vc-certification-service/src/services/sunbird.service.js
+++ b/backend/vc-certification-service/src/services/sunbird.service.js
@@ -52,11 +52,8 @@ const revokeCertificate = (body, token) => {
 }
 
 const searchCertificate = (entityType, filters, token) => {
-    return axios.default.post(`${certifyConstants.SUNBIRD_CERTIFICATE_URL}${entityType}/search`, filters, {headers: {Authorization: token}})
-        .then(res => {
-            console.log('RES : ' , res.data);
-            return res.data.length >= 1
-        })
+    return axios.post(`${certifyConstants.SUNBIRD_CERTIFICATE_URL}${entityType}/search`, filters, {headers: {Authorization: token}})
+        .then(res => res.data.length >= 1)
         .catch(err => {
             console.error(err);
             throw err;

--- a/backend/vc-certification-service/src/services/sunbird.service.js
+++ b/backend/vc-certification-service/src/services/sunbird.service.js
@@ -52,11 +52,14 @@ const revokeCertificate = (body, token) => {
 }
 
 const searchCertificate = (entityType, filters, token) => {
-    return axios.post(`${certifyConstants.SUNBIRD_CERTIFICATE_URL}${entityType}/search`, filters, {headers: {Authorization: token}})
-        .then(res => res.data.length >= 1)
+    return axios.default.post(`${certifyConstants.SUNBIRD_CERTIFICATE_URL}${entityType}/search`, filters, {headers: {Authorization: token}})
+        .then(res => {
+            console.log('RES : ' , res.data);
+            return res.data.length >= 1
+        })
         .catch(err => {
             console.error(err);
-            return false;
+            throw err;
         })
 }
 


### PR DESCRIPTION
Code refactor and send 401 statusCode instead of 400 if search api fails to validate token

@prasanna-egov @saiprakash-v, when token was expired, the response of revoke was still 400 with message as "Certificate not found for ${entityType}"