### PR TITLE
HLM-662 | We need to remove unique constraint for perviousCertificateId in V_RevokedVC table

### DIFF
--- a/vc-registry/RevokedVC.json
+++ b/vc-registry/RevokedVC.json
@@ -48,9 +48,6 @@
     "indexFields": [
       "previousCertificateId"
     ],
-    "uniqueIndexFields": [
-      "previousCertificateId"
-    ],
     "systemFields": [
       "_osCreatedAt",
       "_osUpdatedAt",


### PR DESCRIPTION
Remove unique constraint for previousCertificateId in revoke table. Add checks to soft delete only the records with no endDate and handle duplicate non-deleted revoked records.

@saiprakash-v  @prasanna-egov  @varadeth 