### PR TITLE
removing anonymous role in tenant schema

### DIFF
--- a/vc-registry/Tenant.json
+++ b/vc-registry/Tenant.json
@@ -115,7 +115,7 @@
       "osCreatedBy",
       "osUpdatedBy"
     ],
-    "roles": ["anonymous"],
+    "roles": [],
     "inviteRoles": ["anonymous"],
     "ownershipAttributes": [
       {


### PR DESCRIPTION
When a get request for any entity is made without osid, we send an authorization token to retreive the entries based on osOwner. If the roles attribute in the schema is set to `"anonymous"`, SB-RC recently added a filter to bypass authentication (which completely ignores the token and doesn't generate any userprincipal). So get request doesn't return anything. Now, when `"anonymous"` role is removed, middleware generates userprincipal, which can be used down the line to get osOwner and fetch corresponding entries

Refs: https://github.com/Sunbird-RC/community/issues/303

@prasanna-egov 
